### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "geckodriver": "1.1.2",
     "merge": "1.2.0",
     "phantomjs-prebuilt": "2.1.12",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "selenium-webdriver": "3.0.0"
   }
 }


### PR DESCRIPTION
@john-doherty There is a problem with the version of require-dir being used when using newer versions of node. The version 0.3.0 uses deprecated Node functions which are completely removed in Node 8, version 0.3.2 fixes this issue.