### PR TITLE
Initial stab at adding a definable config file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ global.pageObjectPath = path.resolve(program.pageObjects);
 
 // used within world.js to output reports
 global.reportsPath = path.resolve(program.reports);
+if (!fs.existsSync(program.reports)){
+    fs.makeTreeSync(program.reports);
+}
 
 // used within world.js to decide if reports should be generated
 global.disableLaunchReport = (program.disableLaunchReport);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs-plus');
 var path = require('path');
 var program = require('commander');
 var pjson = require('./package.json');
@@ -10,21 +11,34 @@ function collectPaths(value, paths) {
     return paths;
 }
 
+var config = {
+    "step_def_dir": "./step-definitions",
+    "page_obj_dir": "./page-objects",
+    "shared_obj_dir": "./shared-objects",
+    "reports_dir": "./reports",
+    "default_browser": "chrome",
+    "timeout": 10000
+};
+var configFileName = path.resolve(process.cwd(), 'selenium-cucumber-js.json');
+if (fs.isFileSync(configFileName)) {
+    config = Object.assign(config, require(configFileName));
+}
+
 program
-  .version(pjson.version)
-  .description(pjson.description)
-  .option('-s, --steps <path>', 'path to step definitions. defaults to ./step-definitions', './step-definitions')
-  .option('-p, --pageObjects <path>', 'path to page objects. defaults to ./page-objects', './page-objects')
-  .option('-o, --sharedObjects [paths]', 'path to shared objects (repeatable). defaults to ./shared-objects', collectPaths, ['./shared-objects'])
-  .option('-b, --browser <path>', 'name of browser to use. defaults to chrome', /^(chrome|firefox|phantomjs)$/i, 'chrome')
-  .option('-r, --reports <path>', 'output path to save reports. defaults to ./reports', './reports')
-  .option('-d, --disableLaunchReport [optional]', 'Disables the auto opening the browser with test report')
-  .option('-j, --junit <path>', 'output path to save junit-report.xml defaults to ./reports')
-  .option('-t, --tags <tagName>', 'name of tag to run')
-  .option('-f, --featureFile <path>', 'a specific feature file to run')
-  .option('-x, --timeOut <n>', 'steps definition timeout in milliseconds. defaults to 10 seconds', parseInt)
-  .option('-n, --noScreenshot [optional]', 'disable auto capturing of screenshots when an error is encountered')
-  .parse(process.argv);
+    .version(pjson.version)
+    .description(pjson.description)
+    .option('-s, --steps <path>', 'path to step definitions. defaults to ' + config.step_def_dir, config.step_def_dir)
+    .option('-p, --pageObjects <path>', 'path to page objects. defaults to ' + config.page_obj_dir, config.page_obj_dir)
+    .option('-o, --sharedObjects [paths]', 'path to shared objects (repeatable). defaults to ' + config.shared_obj_dir, collectPaths, [config.shared_obj_dir])
+    .option('-b, --browser <path>', 'name of browser to use. defaults to ' + config.default_browser, config.default_browser)
+    .option('-r, --reports <path>', 'output path to save reports. defaults to ' + config.reports_dir, config.reports_dir)
+    .option('-d, --disableLaunchReport [optional]', 'Disables the auto opening the browser with test report')
+    .option('-j, --junit <path>', 'output path to save junit-report.xml defaults to ' + config.reports_dir)
+    .option('-t, --tags <tagName>', 'name of tag to run')
+    .option('-f, --featureFile <path>', 'a specific feature file to run')
+    .option('-x, --timeOut <n>', 'steps definition timeout in milliseconds. defaults to ' + config.timeout, parseInt, config.timeout)
+    .option('-n, --noScreenshot [optional]', 'disable auto capturing of screenshots when an error is encountered')
+    .parse(process.argv);
 
 program.on('--help', function() {
     console.log('  For more details please visit https://github.com/john-doherty/selenium-cucumber-js#readme\n');


### PR DESCRIPTION
Looks in Node's working directory for the file "selenium-cucumber-js.json".
If found, loads it and merges the definition into the pre-defined config.

A possible improvement would be to load the default config file from the module root, providing an easy example to copy.
However, it's probably just as easy to document the file in the README.md