### PR TITLE
Integrate Applitools with selenium cucumber js .

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -234,6 +234,62 @@ module.exports = function () {
 };
 ```
 
+### Applitools Eyes!
+The Applitools Eyes Selenium JavaScript SDK allows you to easily add visual checkpoints to your JavaScript Selenium tests. 
+It takes care of getting screenshots of your application from the underlying WebDriver, sending them to the Eyes server for validation and failing the test in case differences are found.
+To use Applitools Eyes specifying an ApiKey from Aplitools using a `selenium-cucumber-js.json` file at the root of your project
+
+For example the following configuration could be used with an increased timeout which allows enough time for viusual checks:
+
+```json
+{
+  "eye_key": "Your_Api_Key",
+  "timeout": 50000
+}
+```
+
+And its usage within page Objects:
+
+```js
+module.exports = {
+
+    url: 'https://applitools.com/helloworld',
+
+    elements: {
+        clickme: by.tagName('button'),
+        searchResultLink: by.css('div.g > h3 > a')
+    },
+
+    /**
+     * enters a search term into Google's search box and presses enter
+     * @param {string} searchQuery
+     * @returns {Promise} a promise to enter the search values
+     */
+    applitools_Eyes_Example: function () {
+
+        // Start the test and set the browser's viewport size to 800x600.
+        eyes.open(driver, 'Hello World!', 'My first Javascript test!',
+            {width: 800, height: 600});
+
+        // Navigate the browser to the "hello world!" web-site.
+        driver.get(page.HelloWorld.elements.url);
+
+        // Visual checkpoint #1.
+        eyes.checkWindow('Main Page');
+
+        // Click the "Click me!" button.
+        driver.findElement(page.HelloWorld.elements.clickme).click();
+
+        // Visual checkpoint #2.
+        eyes.checkWindow('Click!');
+
+        // End the test.
+        eyes.close();
+    }
+};
+```
+
+
 ### Before/After hooks
 
 You can register before and after handlers for features and scenarios:

--- a/README.MD
+++ b/README.MD
@@ -260,11 +260,7 @@ module.exports = {
         searchResultLink: by.css('div.g > h3 > a')
     },
 
-    /**
-     * enters a search term into Google's search box and presses enter
-     * @param {string} searchQuery
-     * @returns {Promise} a promise to enter the search values
-     */
+    
     applitools_Eyes_Example: function () {
 
         // Start the test and set the browser's viewport size to 800x600.

--- a/index.js
+++ b/index.js
@@ -53,19 +53,22 @@ program
     .option('-n, --noScreenshot [optional]', 'disable auto capturing of screenshots when an error is encountered')
     .parse(process.argv);
 
-program.on('--help', function() {
+program.on('--help', function () {
     console.log('  For more details please visit https://github.com/john-doherty/selenium-cucumber-js#readme\n');
 });
 
 // store browserName globally (used within world.js to build driver)
 global.browserName = program.browser;
 
+// store Eyes Api globally (used within world.js to set Eyes)
+global.eyeskey = config.eye_key
+
 // used within world.js to import page objects
 global.pageObjectPath = path.resolve(program.pageObjects);
 
 // used within world.js to output reports
 global.reportsPath = path.resolve(program.reports);
-if (!fs.existsSync(program.reports)){
+if (!fs.existsSync(program.reports)) {
     fs.makeTreeSync(program.reports);
 }
 
@@ -82,7 +85,7 @@ global.junitPath = path.resolve(program.junit || program.reports);
 global.DEFAULT_TIMEOUT = global.DEFAULT_TIMEOUT || program.timeOut || 10 * 1000;
 
 // used within world.js to import shared objects into the shared namespace
-global.sharedObjectPaths = program.sharedObjects.map(function(item) {
+global.sharedObjectPaths = program.sharedObjects.map(function (item) {
     return path.resolve(item);
 });
 
@@ -111,8 +114,8 @@ process.argv.push(path.resolve(program.steps));
 // add tag
 if (program.tags) {
     program.tags.forEach(function (tag) {
-      process.argv.push('-t');
-      process.argv.push(tag);
+        process.argv.push('-t');
+        process.argv.push(tag);
     })
 }
 

--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
     "fs-plus": "2.9.1",
     "geckodriver": "1.1.2",
     "merge": "1.2.0",
-    "phantomjs-prebuilt": "2.1.12",
     "require-dir": "0.3.2",
     "selenium-webdriver": "3.0.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "eyes.selenium": "0.0.72"
   },
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/runtime/world.js
+++ b/runtime/world.js
@@ -47,7 +47,8 @@ function getDriverInstance() {
 
         case 'electron': {
             driver = new ElectronDriver();
-        } break;
+        }
+            break;
 
         case 'chrome': {
             driver = new ChromeDriver();
@@ -223,18 +224,15 @@ module.exports = function () {
 
                 return driver.close().then(function () {
                     return driver.quit();
-                })
-            }).then(function () {
-                // If the test was aborted before eyes.close was called ends the test as aborted.
-                return eyes.abortIfNotClosed();
-            });
+                }).then(function () {
+                    // If the test was aborted before eyes.close was called ends the test as aborted.
+                    return eyes.abortIfNotClosed();
+                });
+            })
         }
 
         return driver.close().then(function () {
             return driver.quit();
-        }).then(function () {
-            // If the test was aborted before eyes.close was called ends the test as aborted.
-            return eyes.abortIfNotClosed();
-        });
+        })
     });
 };

--- a/runtime/world.js
+++ b/runtime/world.js
@@ -16,6 +16,9 @@ var assert = require('chai').assert;
 var reporter = require('cucumber-html-reporter');
 var cucumberJunit = require('cucumber-junit');
 
+// Initialize the eyes SDK and set your private API key.
+var Eyes = require('eyes.selenium').Eyes;
+
 // drivers
 var FireFoxDriver = require('./firefoxDriver.js');
 var PhantomJSDriver = require('./phantomDriver.js');
@@ -34,19 +37,23 @@ function getDriverInstance() {
 
         case 'firefox': {
             driver = new FireFoxDriver();
-        } break;
+        }
+            break;
 
         case 'phantomjs': {
             driver = new PhantomJSDriver();
-        } break;
+        }
+            break;
 
         case 'electron': {
             driver = new electronDriver();
-        } break;
+        }
+            break;
 
         case 'chrome': {
             driver = new ChromeDriver();
-        } break;
+        }
+            break;
 
         // try to load from file
         default: {
@@ -60,6 +67,21 @@ function getDriverInstance() {
     }
 
     return driver;
+}
+
+
+/**
+ * Initialize the eyes SDK and set your private API key via the config file.*/
+function getEyesInstance() {
+
+    var eyes = new Eyes();
+
+    //retrieve apikey from config file in the project root as defined by the user
+    eyes.setApiKey(eyeskey);
+
+    return eyes;
+
+
 }
 
 function consoleInfo() {
@@ -77,6 +99,7 @@ function createWorld() {
 
     var runtime = {
         driver: null,               // the browser object
+        eyes: null,
         selenium: selenium,         // the raw nodejs selenium driver
         By: selenium.By,            // in keeping with Java expose selenium By
         by: selenium.By,            // provide a javascript lowercase version
@@ -112,7 +135,7 @@ function importSupportObjects() {
 
             if (fs.existsSync(itemPath)) {
 
-                var dir = requireDir(itemPath, { camelcase: true });
+                var dir = requireDir(itemPath, {camelcase: true});
 
                 merge(allDirs, dir);
             }
@@ -130,7 +153,7 @@ function importSupportObjects() {
     if (global.pageObjectPath && fs.existsSync(global.pageObjectPath)) {
 
         // require all page objects using camel case as object names
-        global.page = requireDir(global.pageObjectPath, { camelcase: true });
+        global.page = requireDir(global.pageObjectPath, {camelcase: true});
     }
 
     // add helpers
@@ -149,12 +172,14 @@ module.exports = function () {
     // set the default timeout for all tests
     this.setDefaultTimeout(global.DEFAULT_TIMEOUT);
 
-    // create the driver before scenario if it's not instantiated
-    this.registerHandler('BeforeScenario', function(scenario) {
+    // create the driver and applitools eyes before scenario if it's not instantiated
+    this.registerHandler('BeforeScenario', function (scenario) {
 
-        if (!global.driver) {
+        if (!global.driver || !global.eyes) {
             global.driver = getDriverInstance();
+            global.eyes = getEyesInstance();
         }
+
     });
 
     this.registerHandler('AfterFeatures', function (features, done) {
@@ -196,14 +221,20 @@ module.exports = function () {
 
                 scenario.attach(new Buffer(screenShot, 'base64'), 'image/png');
 
-                return driver.close().then(function() {
+                return driver.close().then(function () {
                     return driver.quit();
-                });
+                })
+            }).then(function () {
+                // If the test was aborted before eyes.close was called ends the test as aborted.
+                return eyes.abortIfNotClosed();
             });
         }
 
-        return driver.close().then(function() {
+        return driver.close().then(function () {
             return driver.quit();
+        }).then(function () {
+            // If the test was aborted before eyes.close was called ends the test as aborted.
+            return eyes.abortIfNotClosed();
         });
     });
 };


### PR DESCRIPTION
The Applitools Eyes Selenium JavaScript SDK allows you to easily add visual checkpoints to your JavaScript Selenium tests.

It takes care of getting screenshots of your application from the underlying WebDriver, sending them to the Eyes server for validation and failing the test in case differences are found.

please see attached links regarding Applitools:    https://www.applitools.com/resources/tutorial/selenium/javascript#step-2

To get up and running create a free Applitools account and take note of the Api keys .
Add the key to the config file in the projects root directory which is then used while getting the eyes instance. 

eyes has also been made globally so it can be accessed in steps which add visual check points as part of automation . 

At some point I would also need to update the read me file  . I havent added any examples but the capability is there if someone needs it . 