### PR TITLE
Inistead of requiring a specific node version, require a minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/john-doherty/selenium-cucumber-js/issues"
   },
   "engines": {
-    "node": ">=6.11.0 "
+    "node": ">=6.11.0"
   },
   "engineStrict": true,
   "homepage": "https://github.com/john-doherty/selenium-cucumber-js#readme",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/john-doherty/selenium-cucumber-js/issues"
   },
   "engines": {
-    "node": ">=6.11.0"
+    "node": ">=6.11.0 "
   },
   "engineStrict": true,
   "homepage": "https://github.com/john-doherty/selenium-cucumber-js#readme",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/john-doherty/selenium-cucumber-js/issues"
   },
   "engines": {
-    "node": "6.11.0"
+    "node": ">=6.11.0"
   },
   "engineStrict": true,
   "homepage": "https://github.com/john-doherty/selenium-cucumber-js#readme",


### PR DESCRIPTION
When using this package with yarn, I find myself having to specify "--ignore-engines". This is because this package requires a specific version of node as an engine, when it should be requiring a minimum version of node.

https://yarnpkg.com/en/docs/cli/install

This fixes #66 