### PR TITLE
Updated geckodriver version, selenium-webdriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "electron-prebuilt": "^1.4.13",
     "eyes.selenium": "0.0.72",
     "fs-plus": "2.9.1",
-    "geckodriver": "1.1.2",
+    "geckodriver": "^1.12.2",
     "merge": "1.2.0",
     "phantomjs-prebuilt": "2.1.12",
     "require-dir": "0.3.2",
-    "selenium-webdriver": "3.0.0"
+    "selenium-webdriver": "3.5.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/runtime/world.js
+++ b/runtime/world.js
@@ -227,23 +227,16 @@ module.exports = function () {
 
                 scenario.attach(new Buffer(screenShot, 'base64'), 'image/png');
 
-                return driver.close().then(function () {
-                    return driver.quit();
-                })
-                .then(function() {
-
+                return driver.close().then(function() {
                     if (eyes) {
                         // If the test was aborted before eyes.close was called ends the test as aborted.
                         return eyes.abortIfNotClosed();
                     }
-
                     return Promise.resolve();
                 });
             });
         }
 
-        return driver.close().then(function () {
-            return driver.quit();
-        })
+        return driver.close()
     });
 };

--- a/shippable.yml
+++ b/shippable.yml
@@ -4,10 +4,10 @@ node_js:
   - 6.9.0
 
 addons:
-    firefox: "49.0"
+    firefox: "57.0"
 
 env:
-  global:
+  globali:
     - CHROME_VERSION=google-chrome-stable
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - NODE_ENV=test

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,7 +7,7 @@ addons:
     firefox: "57.0"
 
 env:
-  globali:
+  global:
     - CHROME_VERSION=google-chrome-stable
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
     - NODE_ENV=test


### PR DESCRIPTION
This meant also bumping the firefox version for shippable.
For the newer version of geckodriver - changed world.js as driver.quit is redundant after driver.close in single window, and this meant test was failing in shippable. (https://github.com/mozilla/geckodriver/issues/966) 