### PR TITLE
Browser teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode
 node_modules
 package-lock.json
-. idea/
+.idea/

--- a/README.MD
+++ b/README.MD
@@ -41,19 +41,20 @@ node ./node_modules/selenium-cucumber-js/index.js -s ./step-definitions
 ### Options
 
 ```bash
--h, --help                   output usage information
--V, --version                output the version number
--s, --steps <path>           path to step definitions. defaults to ./step-definitions
--p, --pageObjects <path>     path to page objects. defaults to ./page-objects
--o, --sharedObjects [paths]  path to shared objects (repeatable). defaults to ./shared-objects
--b, --browser <path>         name of browser to use. defaults to chrome
--r, --reports <path>         output path to save reports. defaults to ./reports
--d, --disableLaunchReport    disable the auto opening the browser with test report
--j, --junit <path>           output path to save junit-report.xml defaults to ./reports
--t, --tags <tagName>         name of tag to run
--f, --featureFile <path>     a specific feature file to run
--x, --timeOut <n>            steps definition timeout in milliseconds. defaults to 10 seconds
--n, --noScreenshot           disable auto capturing of screenshots when an error is encountered
+-h, --help                          output usage information
+-V, --version                       output the version number
+-s, --steps <path>                  path to step definitions. defaults to ./step-definitions
+-p, --pageObjects <path>            path to page objects. defaults to ./page-objects
+-o, --sharedObjects [paths]         path to shared objects (repeatable). defaults to ./shared-objects
+-b, --browser <path>                name of browser to use. defaults to chrome
+-k, --browser-teardown <optional>   browser teardown strategy after every scenario (always, clear, none). defaults to "always"
+-r, --reports <path>                output path to save reports. defaults to ./reports
+-d, --disableLaunchReport           disable the auto opening the browser with test report
+-j, --junit <path>                  output path to save junit-report.xml defaults to ./reports
+-t, --tags <tagName>                name of tag to run
+-f, --featureFile <path>            a specific feature file to run
+-x, --timeOut <n>                   steps definition timeout in milliseconds. defaults to 10 seconds
+-n, --noScreenshot                  disable auto capturing of screenshots when an error is encountered
 ```
 
 By default tests are run using Google Chrome, to run tests using another browser supply the name of that browser along with the `-b` switch. Available options are:
@@ -112,7 +113,16 @@ Feature: Searching for vote cards app
     Then I should see some results
 ```
 
-The browser automatically closes after each scenario to ensure the next scenario uses a fresh browser environment.
+### Browser teardown strategy
+
+The browser automatically closes after each scenario to ensure the next scenario uses a fresh browser environment. But
+you can change this behavior with the "-k" or the "--browser-teardown" parameter.
+
+Value      |  Description
+---------- | ---------------
+`always`   | the browser automatically closes (default)
+`clear`    | the browser automatically clears cookies, local and session storages
+`none`     | the browser does nothing
 
 ### Step definitions
 
@@ -270,6 +280,15 @@ helpers.getPseudoElementBeforeValue('body header');
 
 // get the content value of a :after pseudo element
 helpers.getPseudoElementAfterValue('body header');
+
+// clear the cookies
+helpers.clearCookies();
+
+// clear both local and session storages
+helpers.clearStorages();
+
+// clear both cookies and storages
+helpers.clearCookiesAndStorages('body header');
 ```
 
 ### Visual Comparison

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ program
     .option('-p, --pageObjects <path>', 'path to page objects. defaults to ' + config.pageObjects, config.pageObjects)
     .option('-o, --sharedObjects [paths]', 'path to shared objects (repeatable). defaults to ' + config.sharedObjects, collectPaths, [config.sharedObjects])
     .option('-b, --browser <path>', 'name of browser to use. defaults to ' + config.browser, config.browser)
-    .option('-k, --browser-teardown <optional>', 'browser teardown strategy after every scenario (always, clear, none). defaults to "none"', config.browserTeardownStrategy)
+    .option('-k, --browser-teardown <optional>', 'browser teardown strategy after every scenario (always, clear, none). defaults to "always"', config.browserTeardownStrategy)
     .option('-r, --reports <path>', 'output path to save reports. defaults to ' + config.reports, config.reports)
     .option('-d, --disableLaunchReport [optional]', 'Disables the auto opening the browser with test report')
     .option('-j, --junit <path>', 'output path to save junit-report.xml defaults to ' + config.reports)

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ var config = {
     sharedObjects: './shared-objects',
     reports: './reports',
     browser: 'chrome',
+    browserTeardownStrategy: 'always',
     timeout: 15000
 };
 
@@ -44,6 +45,7 @@ program
     .option('-p, --pageObjects <path>', 'path to page objects. defaults to ' + config.pageObjects, config.pageObjects)
     .option('-o, --sharedObjects [paths]', 'path to shared objects (repeatable). defaults to ' + config.sharedObjects, collectPaths, [config.sharedObjects])
     .option('-b, --browser <path>', 'name of browser to use. defaults to ' + config.browser, config.browser)
+    .option('-k, --browser-teardown <optional>', 'browser teardown strategy after every scenario (always, clear, none). defaults to "none"', config.browserTeardownStrategy)
     .option('-r, --reports <path>', 'output path to save reports. defaults to ' + config.reports, config.reports)
     .option('-d, --disableLaunchReport [optional]', 'Disables the auto opening the browser with test report')
     .option('-j, --junit <path>', 'output path to save junit-report.xml defaults to ' + config.reports)
@@ -59,6 +61,7 @@ program.on('--help', function () {
 
 // store browserName globally (used within world.js to build driver)
 global.browserName = program.browser;
+global.browserTeardownStrategy = program.browserTeardown;
 
 // store Eyes Api globally (used within world.js to set Eyes)
 global.eyesKey = config.eye_key;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chromedriver": "^2.41.0",
     "commander": "2.9.0",
     "cucumber": "1.3.3",
-    "cucumber-html-reporter": "2.0.3",
+    "cucumber-html-reporter": "4.0.4",
     "cucumber-junit": "1.6.0",
     "electron": "^1.7.6",
     "electron-chromedriver": "^1.7.1",

--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -259,5 +259,17 @@ module.exports = {
         }
 
         return driver.executeScript(getAfterContentValue, cssSelector);
+    },
+
+    clearCookies: function() {
+        return driver.manage().deleteAllCookies();
+    },
+
+    clearStorages: function() {
+        return driver.executeScript('window.localStorage.clear(); window.sessionStorage.clear();')
+    },
+
+    clearCookiesAndStorages: function() {
+        return helpers.clearCookies().then(helpers.clearStorages());
     }
 };

--- a/runtime/world.js
+++ b/runtime/world.js
@@ -242,7 +242,7 @@ module.exports = function () {
             closeBrowser().then(() => done());
         }
         else {
-            new Promise(() => {}).then(() => done());
+            new Promise((resolve) => resolve(done()));
         }
     });
 


### PR DESCRIPTION
This PR adds the feature that allows the user to choice different browser teardown strategies.

The default behavior is to close the browser after every scenario, but you can just clear cookies and storages of do nothing and let the user to reset some data if he want.