### PR TITLE
Added support for cucumber-js world-parameters <JSON>

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ program
     .option('-f, --featureFiles <paths>', 'comma-separated list of feature files to run')
     .option('-x, --timeOut <n>', 'steps definition timeout in milliseconds. defaults to ' + config.timeout, coerceInt, config.timeout)
     .option('-n, --noScreenshot [optional]', 'disable auto capturing of screenshots when an error is encountered')
+    .option('-w, --worldParameters <JSON>', 'JSON object to pass to cucumber-js world constructor. defaults to empty', config.worldParameters)
     .parse(process.argv);
 
 program.on('--help', function () {
@@ -124,6 +125,11 @@ if (program.tags) {
         process.argv.push('-t');
         process.argv.push(tag);
     });
+}
+
+if (program.worldParameters){
+    process.argv.push('--world-parameters');
+    process.argv.push(program.worldParameters);
 }
 
 // add strict option (fail if there are any undefined or pending steps)


### PR DESCRIPTION
This adds support/passthrough for cucumber-js's [world-parameters CLI argument](https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md#world-parameters). This simply checks for a `worldParameters` argument. If it exists, it is passed along to cucumber-js. If not, it is ignored. I am using it to facilitate updating test results in Testuff by passing in a Testuff suiteId to the CLI. Then calling Testuff's API with the suiteId after each scenario.  

## Usage example (CLI)

`index.js -s ./step-definitions  --worldParameters '{"testSuiteId":12341234}'`  

## Usage example (world.js)

```javascript
let worldParams = {};

this.World = function(worldParameters){
    worldParams = worldParameters;
};

this.After(function (scenario, callback){
    let suiteId = worldParams.testSuiteId;
    // Perhaps update some test management API using suiteId
    callback();
});
```